### PR TITLE
Add support for Haml templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### 0.2.0 (in development)
 
+- New: support for [Haml](https://github.com/haml/haml) templates
+
 ### 0.1.0 (2017-01-11)
 
 - First release!

--- a/flutterby.gemspec
+++ b/flutterby.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sass', '~> 3.4'
   spec.add_dependency 'tilt', '~> 2.0'
   spec.add_dependency 'slim', '~> 3.0'
+  spec.add_dependency 'haml', '~> 4.0'
   spec.add_dependency 'toml-rb', '~> 0.3'
   spec.add_dependency 'rack', '~> 2.0'
   spec.add_dependency 'listen', '~> 3.1'

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -1,6 +1,7 @@
 require 'sass'
 require 'tilt'
 require 'slim'
+require 'haml'
 require 'builder'
 require 'slodown'
 
@@ -41,6 +42,10 @@ end
 
 Flutterby::Filters.add("slim") do |node|
   node.body = tilt("slim", node.body).render(node.view)
+end
+
+Flutterby::Filters.add("haml") do |node|
+  node.body = tilt("haml", node.body).render(node.view)
 end
 
 Flutterby::Filters.add(["md", "markdown"]) do |node|

--- a/spec/filters/haml_spec.rb
+++ b/spec/filters/haml_spec.rb
@@ -1,0 +1,19 @@
+describe "Haml filter" do
+  let :source do
+    <<~EOF
+    %ul.foo
+      %li.bar baz
+    EOF
+  end
+
+  let :expected_body do
+    %{<ul class='foo'>\n  <li class='bar'>baz</li>\n</ul>\n}
+  end
+
+  subject do
+    node "index.html.haml", source: source
+  end
+
+  its(:full_name) { is_expected.to eq("index.html") }
+  its(:body) { is_expected.to eq(expected_body)}
+end


### PR DESCRIPTION
This adds support for Haml templates. Currently raises some warnings I need to investigate and fix:

~~~
/Users/hmans/.gem/ruby/2.4.0/gems/tilt-2.0.5/lib/tilt/haml.rb:50:in `block in precompiled_postamble': Haml::Engine#precompiled_method_return_value at /opt/rubies/ruby-2.4.0/lib/ruby/2.4.0/forwardable.rb:156 forwarding to private method Haml::Compiler#precompiled_method_return_value
~~~

Possible an issue between the `haml` and `tilt` gems?