### PR TITLE
Dynamic Tilt support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ### 0.2.0 (in development)
 
+- NEW: For filters not natively supported by Flutterby, it will now fall back to [Tilt]. This means you can just add any gem supported by Tilt to your project to use it as a template language, with no Flutterby-specific plugin required. Hooray!
+
 ### 0.1.0 (2017-01-11)
 
 - First release!
+
+
+
+
+[Tilt]: https://github.com/rtomayko/tilt

--- a/flutterby.gemspec
+++ b/flutterby.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'awesome_print', '~> 0'
   spec.add_development_dependency 'gem-release', '~> 0'
   spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'haml', '~> 4.0'
 
   spec.add_dependency 'json', '~> 2.0'
   spec.add_dependency 'thor', '~> 0.19'

--- a/flutterby.gemspec
+++ b/flutterby.gemspec
@@ -34,12 +34,16 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'highline', '~> 1.7'
   spec.add_dependency 'slodown', '~> 0.3'
-  spec.add_dependency 'builder', '~> 3.2'
-  spec.add_dependency 'sass', '~> 3.4'
-  spec.add_dependency 'tilt', '~> 2.0'
-  spec.add_dependency 'slim', '~> 3.0'
   spec.add_dependency 'toml-rb', '~> 0.3'
   spec.add_dependency 'rack', '~> 2.0'
   spec.add_dependency 'listen', '~> 3.1'
   spec.add_dependency 'mime-types', '~> 3.1'
+
+  # We support some template engines out of the box.
+  # There's a chance these will be extracted/made optional
+  # at some point in the future.
+  spec.add_dependency 'sass', '~> 3.4'
+  spec.add_dependency 'builder', '~> 3.2'
+  spec.add_dependency 'slim', '~> 3.0'
+  spec.add_dependency 'tilt', '~> 2.0'
 end

--- a/flutterby.gemspec
+++ b/flutterby.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'awesome_print', '~> 0'
   spec.add_development_dependency 'gem-release', '~> 0'
   spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'haml', '~> 4.0'
 
   spec.add_dependency 'json', '~> 2.0'
   spec.add_dependency 'thor', '~> 0.19'

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -39,14 +39,6 @@ Flutterby::Filters.add("rb") do |node|
   node.instance_eval(node.body)
 end
 
-Flutterby::Filters.add("erb") do |node|
-  node.body = tilt("erb", node.body).render(node.view)
-end
-
-Flutterby::Filters.add("slim") do |node|
-  node.body = tilt("slim", node.body).render(node.view)
-end
-
 Flutterby::Filters.add(["md", "markdown"]) do |node|
   node.body = Slodown::Formatter.new(node.body).complete.to_s
 end

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -55,9 +55,3 @@ Flutterby::Filters.add("scss") do |node|
 
   node.body = Sass::Engine.new(node.body, sass_options).render
 end
-
-Flutterby::Filters.add("builder") do |node|
-  xml = Builder::XmlMarkup.new
-  node.view.instance_eval(node.body)
-  node.body = xml.target!
-end

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -15,6 +15,10 @@ module Flutterby
 
         if Filters.respond_to?(meth)
           Filters.send(meth, node)
+        elsif template = tilt(filter, node.body)
+          node.body = template.render
+        else
+          Flutterby.logger.warn "Unsupported filter '#{filter}' for #{node.url}"
         end
       end
     end
@@ -26,7 +30,7 @@ module Flutterby
     end
 
     def self.tilt(format, body)
-      Tilt[format].new { body }
+      t = Tilt[format] and t.new { body }
     end
   end
 end

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -16,7 +16,7 @@ module Flutterby
         if Filters.respond_to?(meth)
           Filters.send(meth, node)
         elsif template = tilt(filter, node.body)
-          node.body = template.render
+          node.body = template.render(node.view)
         else
           Flutterby.logger.warn "Unsupported filter '#{filter}' for #{node.url}"
         end

--- a/spec/filters/builder_spec.rb
+++ b/spec/filters/builder_spec.rb
@@ -13,7 +13,7 @@ describe "XMLBuilder filter" do
   end
 
   let :output do
-    %{<?xml version=\"1.0\" encoding=\"UTF-8\"?><test><name>feed</name><bar>baz</bar></test>}
+    %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<test>\n  <name>feed</name>\n  <bar>baz</bar>\n</test>\n}
   end
 
   subject do

--- a/spec/filters/tilt_spec.rb
+++ b/spec/filters/tilt_spec.rb
@@ -1,0 +1,25 @@
+# We're doing most template rendering through Tilt, so we can
+# leverage this to dynamically fall back to it for template formats
+# we don't support out of the box.
+
+require 'haml'
+
+describe "Tilt template fallback" do
+  let :source do
+    <<~EOF
+    %ul.foo
+      %li.bar baz
+    EOF
+  end
+
+  let :expected_body do
+    %{<ul class='foo'>\n  <li class='bar'>baz</li>\n</ul>\n}
+  end
+
+  subject do
+    node "index.html.haml", source: source
+  end
+
+  its(:full_name) { is_expected.to eq("index.html") }
+  its(:body) { is_expected.to eq(expected_body) }
+end

--- a/spec/filters/tilt_spec.rb
+++ b/spec/filters/tilt_spec.rb
@@ -2,22 +2,19 @@
 # leverage this to dynamically fall back to it for template formats
 # we don't support out of the box.
 
-require 'haml'
-
 describe "Tilt template fallback" do
   let :source do
     <<~EOF
-    %ul.foo
-      %li.bar baz
+    # RDoc test. +Yeah+!
     EOF
   end
 
   let :expected_body do
-    %{<ul class='foo'>\n  <li class='bar'>baz</li>\n</ul>\n}
+    %{\n<p># RDoc test. <code>Yeah</code>!</p>\n}
   end
 
   subject do
-    node "index.html.haml", source: source
+    node "index.html.rdoc", source: source
   end
 
   its(:full_name) { is_expected.to eq("index.html") }

--- a/spec/filters/unsupported_filter_spec.rb
+++ b/spec/filters/unsupported_filter_spec.rb
@@ -1,0 +1,16 @@
+describe "Unsupported filters" do
+  subject { node "index.html.poop", source: source }
+
+  let :source { "poop!" }
+
+  its(:full_name) { is_expected.to eq("index.html") }
+  its(:body) { is_expected.to eq(source) }
+
+  specify "logs a warning" do
+    expect(Flutterby.logger)
+      .to receive(:warn)
+      .with("Unsupported filter 'poop' for /index.html")
+
+    subject.render_body!
+  end
+end

--- a/spec/filters/unsupported_filter_spec.rb
+++ b/spec/filters/unsupported_filter_spec.rb
@@ -1,7 +1,7 @@
 describe "Unsupported filters" do
   subject { node "index.html.poop", source: source }
 
-  let :source { "poop!" }
+  let(:source) { "poop!" }
 
   its(:full_name) { is_expected.to eq("index.html") }
   its(:body) { is_expected.to eq(source) }


### PR DESCRIPTION
Flutterby now falls back to Tilt when a built-in filter method for the requested format could not be found.

This essentially means that you can just add template engine gems to your Flutterby project, and they'll just work as expected -- no Flutterby-specific plugins required.