### PR TITLE
Add ActiveSupport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### 0.3.0 (in development)
 
+- **NEW:** Flutterby now uses ActiveSupport. It's a big dependency, but there's just so much useful goodness in there -- let's ride on the shoulders of that giant! This allows you to use all the neat little ActiveSupport toys you may know from Rails in your Flutterby project.
+- **CHANGE:** Thanks to the new inclusion of ActiveSupport, Flutterby now properly deals with HTML escaping (by way of `ActiveSupport::SafeBuffer`). This may not be critically important to static sites, but since Flutterby aspires to also power live sites, better make this change now than later. To sum things up, Flutterby now deals with HTML escaping pretty much like Rails does. Hooray!
+
 
 ### 0.2.0 (2017-01-13)
 

--- a/flutterby.gemspec
+++ b/flutterby.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'gem-release', '~> 0'
   spec.add_development_dependency 'pry', '~> 0.10'
 
+  spec.add_dependency 'erubis', '~> 2.7'
   spec.add_dependency 'json', '~> 2.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'highline', '~> 1.7'

--- a/flutterby.gemspec
+++ b/flutterby.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'listen', '~> 3.1'
   spec.add_dependency 'mime-types', '~> 3.1'
   spec.add_dependency 'better_errors', '~> 2.1'
+  spec.add_dependency 'activesupport', '~> 5.0'
 
   # We support some template engines out of the box.
   # There's a chance these will be extracted/made optional

--- a/flutterby.gemspec
+++ b/flutterby.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
 
   spec.add_dependency 'erubis', '~> 2.7'
+  spec.add_dependency 'erubis-auto', '~> 1.0.1'
   spec.add_dependency 'json', '~> 2.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'highline', '~> 1.7'

--- a/lib/flutterby.rb
+++ b/lib/flutterby.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'toml'
 require 'mime-types'
 require 'json'

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -16,7 +16,7 @@ module Flutterby
         if Filters.respond_to?(meth)
           Filters.send(meth, node)
         elsif template = tilt(filter, node.body)
-          node.body = template.render(node.view)
+          node.body = template.render(node.view).html_safe
         else
           Flutterby.logger.warn "Unsupported filter '#{filter}' for #{node.url}"
         end

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -9,7 +9,7 @@ require 'flutterby/markdown_formatter'
 module Flutterby
   module Filters
     def self.apply!(node)
-      node.body = node.source
+      node.body = node.source.try(:html_safe)
 
       # Apply all filters
       node.filters.each do |filter|

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -30,8 +30,7 @@ module Flutterby
     end
 
     def self.tilt(format, body)
-      t = Tilt[format] and
-        t.new(outvar: "self._safe_buffer") { body }
+      t = Tilt[format] and t.new() { body }
     end
   end
 end

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -40,7 +40,7 @@ Flutterby::Filters.add("rb") do |node|
 end
 
 Flutterby::Filters.add(["md", "markdown"]) do |node|
-  node.body = Flutterby::MarkdownFormatter.new(node.body).complete.to_s
+  node.body = Flutterby::MarkdownFormatter.new(node.body).complete.to_s.html_safe
 end
 
 Flutterby::Filters.add("scss") do |node|

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -1,4 +1,5 @@
 require 'erubis'
+require 'erubis/auto'
 require 'sass'
 require 'tilt'
 require 'slim'
@@ -30,15 +31,16 @@ module Flutterby
       end
     end
 
-    def self.tilt(format, body)
-      t = Tilt[format] and t.new() { body }
+    def self.tilt(format, body, options = {})
+      default_options = {
+        "erb" => { engine_class: Erubis::Auto::EscapedEruby }
+      }
+
+      options = default_options.fetch(format, {}).merge(options)
+
+      t = Tilt[format] and t.new(options) { body }
     end
   end
-end
-
-Flutterby::Filters.add("erb") do |node|
-  template = Tilt::ErubisTemplate.new(escape_html: true) { node.body }
-  node.body = template.render(node.view)
 end
 
 Flutterby::Filters.add("rb") do |node|

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -35,6 +35,11 @@ module Flutterby
   end
 end
 
+Flutterby::Filters.add("erb") do |node|
+  template = Tilt::ErubisTemplate.new(escape: true) { node.body }
+  node.body = template.render(node.view)
+end
+
 Flutterby::Filters.add("rb") do |node|
   node.instance_eval(node.body)
 end

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -30,7 +30,8 @@ module Flutterby
     end
 
     def self.tilt(format, body)
-      t = Tilt[format] and t.new { body }
+      t = Tilt[format] and
+        t.new(outvar: "self._safe_buffer") { body }
     end
   end
 end

--- a/lib/flutterby/filters.rb
+++ b/lib/flutterby/filters.rb
@@ -1,3 +1,4 @@
+require 'erubis'
 require 'sass'
 require 'tilt'
 require 'slim'
@@ -36,7 +37,7 @@ module Flutterby
 end
 
 Flutterby::Filters.add("erb") do |node|
-  template = Tilt::ErubisTemplate.new(escape: true) { node.body }
+  template = Tilt::ErubisTemplate.new(escape_html: true) { node.body }
   node.body = template.render(node.view)
 end
 

--- a/lib/flutterby/node.rb
+++ b/lib/flutterby/node.rb
@@ -252,9 +252,9 @@ module Flutterby
     end
 
     def apply_layout(input)
-      walk_up(input) do |e, current|
-        if layout = e.sibling("_layout")
-          tilt = Tilt[layout.ext].new { layout.source }
+      walk_up(input) do |node, current|
+        if layout = node.sibling("_layout")
+          tilt = Flutterby::Filters.tilt(layout.ext, layout.source)
           tilt.render(view) { current }.html_safe
         else
           current

--- a/lib/flutterby/node.rb
+++ b/lib/flutterby/node.rb
@@ -255,7 +255,7 @@ module Flutterby
       walk_up(input) do |e, current|
         if layout = e.sibling("_layout")
           tilt = Tilt[layout.ext].new { layout.source }
-          tilt.render(view) { current }
+          tilt.render(view) { current }.html_safe
         else
           current
         end

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -5,8 +5,7 @@ module Flutterby
 
     concerning :SafeBuffer do
       def _safe_buffer=(v)
-        @_safe_buffer ||= ActiveSupport::SafeBuffer.new("")
-        @_safe_buffer << v
+        @_safe_buffer = v.is_a?(String) ? ActiveSupport::SafeBuffer.new(v) : v
       end
 
       def _safe_buffer

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -12,6 +12,10 @@ module Flutterby
       date.strftime(fmt)
     end
 
+    def raw(str)
+      str.html_safe
+    end
+
     def render(expr, *args)
       find(expr).render(*args)
     end

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -3,6 +3,13 @@ module Flutterby
     attr_reader :node, :opts
     alias_method :page, :node
 
+    # Include ERB::Util from ActiveSupport. This will provide
+    # html_escape, h, and json_escape helpers.
+    #
+    # http://api.rubyonrails.org/classes/ERB/Util.html
+    #
+    include ERB::Util
+
     def initialize(node)
       @node = node
       @opts = {}
@@ -29,6 +36,9 @@ module Flutterby
     end
 
     class << self
+      # Factory method that returns a newly created view for the given node.
+      # It also makes sure all available _view.rb extensions are loaded.
+      #
       def for(file)
         # create a new view instance
         view = new(file)

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -3,16 +3,6 @@ module Flutterby
     attr_reader :node, :opts
     alias_method :page, :node
 
-    concerning :SafeBuffer do
-      def _safe_buffer=(v)
-        @_safe_buffer = v.is_a?(String) ? ActiveSupport::SafeBuffer.new(v) : v
-      end
-
-      def _safe_buffer
-        @_safe_buffer
-      end
-    end
-
     def initialize(node)
       @node = node
       @opts = {}

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -3,6 +3,17 @@ module Flutterby
     attr_reader :node, :opts
     alias_method :page, :node
 
+    concerning :SafeBuffer do
+      def _safe_buffer=(v)
+        @_safe_buffer ||= ActiveSupport::SafeBuffer.new("")
+        @_safe_buffer << v
+      end
+
+      def _safe_buffer
+        @_safe_buffer
+      end
+    end
+
     def initialize(node)
       @node = node
       @opts = {}

--- a/lib/templates/new_project/site/_layout.slim
+++ b/lib/templates/new_project/site/_layout.slim
@@ -14,7 +14,7 @@ html
   
   body
     .container
-      == yield 
+      = yield
 
       footer role="main"
         = config["site"]["description"]

--- a/lib/templates/new_project/site/_layout.slim
+++ b/lib/templates/new_project/site/_layout.slim
@@ -15,6 +15,6 @@ html
   body
     .container
       = yield
-
+      
       footer role="main"
         = config["site"]["description"]

--- a/lib/templates/new_project/site/blog/_layout.slim
+++ b/lib/templates/new_project/site/blog/_layout.slim
@@ -4,4 +4,4 @@ article.post
 
   h1 = page.title
 
-  == page.body
+  = page.body

--- a/spec/html_escaping_spec.rb
+++ b/spec/html_escaping_spec.rb
@@ -6,11 +6,11 @@ describe "html escaping" do
 
     let(:source) do
       <<~EOF
-      <%= "Hi! <g>" %>
+      <p><%= "Hi! <g>" %></p>
       EOF
     end
 
-    its(:body) { is_expected.to include("Hi! &lt;g&gt;") }
+    its(:body) { is_expected.to include("<p>Hi! &lt;g&gt;</p>") }
   end
 
   context "with Slim" do
@@ -20,10 +20,10 @@ describe "html escaping" do
 
     let(:source) do
       <<~EOF
-      = "Hi! <g>"
+      p = "Hi! <g>"
       EOF
     end
 
-    its(:body) { is_expected.to include("Hi! &lt;g&gt;") }
+    its(:body) { is_expected.to include("<p>Hi! &lt;g&gt;</p>") }
   end
 end

--- a/spec/html_escaping_spec.rb
+++ b/spec/html_escaping_spec.rb
@@ -1,0 +1,29 @@
+describe "html escaping" do
+  context "with ERB" do
+    subject do
+      node "page.html.erb", source: source
+    end
+
+    let(:source) do
+      <<~EOF
+      <%= "Hi! <g>" %>
+      EOF
+    end
+
+    its(:body) { is_expected.to eq("Moo") }
+  end
+
+  context "with Slim" do
+    subject do
+      node "page.html.slim", source: source
+    end
+
+    let(:source) do
+      <<~EOF
+      = "Hi! <g>"
+      EOF
+    end
+
+    its(:body) { is_expected.to eq("Hi! &lt;g&gt;") }
+  end
+end

--- a/spec/html_escaping_spec.rb
+++ b/spec/html_escaping_spec.rb
@@ -10,7 +10,7 @@ describe "html escaping" do
       EOF
     end
 
-    its(:body) { is_expected.to eq("Moo") }
+    its(:body) { is_expected.to include("Hi! &lt;g&gt;") }
   end
 
   context "with Slim" do
@@ -24,6 +24,6 @@ describe "html escaping" do
       EOF
     end
 
-    its(:body) { is_expected.to eq("Hi! &lt;g&gt;") }
+    its(:body) { is_expected.to include("Hi! &lt;g&gt;") }
   end
 end

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -3,7 +3,7 @@ describe "layouts" do
 
   let!(:outer_layout) do
     node "_layout.erb", parent: root, source: <<~EOF
-    <h1>Outer Layout</h1>
+    <h1><%= "Outer Layout <g>" %></h1>
     <%= yield %>
     EOF
   end
@@ -26,7 +26,7 @@ describe "layouts" do
   end
 
   let(:expected_output) do
-    %{<h1>Outer Layout</h1>\n<h2>Inner Layout</h2>\n<p>I'm the actual page!</p>\n\n\n}
+    %{<h1>Outer Layout &lt;g&gt;</h1>\n<h2>Inner Layout</h2>\n<p>I'm the actual page!</p>\n\n\n}
   end
 
   specify do

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -1,5 +1,5 @@
 describe Flutterby::View do
-  subject { node "page.html.erb", source: %{<%= raw "<g>" %>} }
+  subject { node "page.html.erb", source: source }
 
   describe '#raw' do
     let(:source) { %{<%= raw "<g>" %>} }
@@ -7,6 +7,12 @@ describe Flutterby::View do
   end
 
   describe '#html_escape' do
-    pending  # NOTE: test View instance instead
+    let(:source) { %{<%= raw(html_escape "<g>") %>} }
+    its(:body) { is_expected.to eq('&lt;g&gt;') }
+  end
+
+  describe '#h' do
+    let(:source) { %{<%= raw(h "<g>") %>} }
+    its(:body) { is_expected.to eq('&lt;g&gt;') }
   end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -1,3 +1,12 @@
 describe Flutterby::View do
-  pending
+  subject { node "page.html.erb", source: %{<%= raw "<g>" %>} }
+
+  describe '#raw' do
+    let(:source) { %{<%= raw "<g>" %>} }
+    its(:body) { is_expected.to eq("<g>") }
+  end
+
+  describe '#html_escape' do
+    pending  # NOTE: test View instance instead
+  end
 end


### PR DESCRIPTION
Mostly for SafeBuffer, which allows us to deal with HTML escaping in a sane fashion.

**TODO:**

- [x] Add and load ActiveSupport dependency
- [x] Add and tweak Erubis to use SafeBuffer
- [x] Write specs to test HTML escaping
- [x] Add `raw` view helper
- [x] Add `html_escape` and `h` view helpers