### PR TITLE
Tag and link helpers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### 0.4.0 (in development)
 
+- **NEW:** Flutterby views now have a `tag` helper method available that can generate HTML tags programatically.
+- **NEW:** Flutterby views now have a `link_to` helper method available that renders link tags. You can use a URL string as the link target, eg. `link_to "Home", "/"`, or any Flutterby node, eg. `link_to "Blog", blog_node`.
+
 
 ### 0.3.1 (2017-01-15)
 

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -41,13 +41,10 @@ module Flutterby
           %{#{h k}="#{h v}"}
         end.join(" ")
 
-        opening_tag = "#{name.downcase} #{attributes_str}".strip
+        opening_tag = "#{h name.downcase} #{attributes_str}".strip
         output << "<#{opening_tag}>".html_safe
-
-        if block_given?
-          output << yield
-          output << "</#{name}>".html_safe
-        end
+        output << yield if block_given?
+        output << "</#{h name}>".html_safe
       end
     end
 

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -49,7 +49,12 @@ module Flutterby
     end
 
     def link_to(text, target, attrs = {})
-      tag(:a, attrs.merge(href: target.url)) { text }
+      href = case target
+      when Flutterby::Node then target.url
+      else target.to_s
+      end
+
+      tag(:a, attrs.merge(href: href)) { text }
     end
 
     class << self

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -37,8 +37,8 @@ module Flutterby
 
     def tag(name, attributes)
       ActiveSupport::SafeBuffer.new.tap do |output|
-        attributes_str = attributes.map do |k, v|
-          %{#{h k}="#{h v}"}
+        attributes_str = attributes.keys.sort.map do |k|
+          %{#{h k}="#{h attributes[k]}"}
         end.join(" ")
 
         opening_tag = "#{h name.downcase} #{attributes_str}".strip
@@ -48,8 +48,8 @@ module Flutterby
       end
     end
 
-    def link_to(text, target)
-      tag(:a, href: target.url) { text }
+    def link_to(text, target, attrs = {})
+      tag(:a, attrs.merge(href: target.url)) { text }
     end
 
     class << self

--- a/lib/flutterby/view.rb
+++ b/lib/flutterby/view.rb
@@ -35,6 +35,26 @@ module Flutterby
       node.siblings(*args)
     end
 
+    def tag(name, attributes)
+      ActiveSupport::SafeBuffer.new.tap do |output|
+        attributes_str = attributes.map do |k, v|
+          %{#{h k}="#{h v}"}
+        end.join(" ")
+
+        opening_tag = "#{name.downcase} #{attributes_str}".strip
+        output << "<#{opening_tag}>".html_safe
+
+        if block_given?
+          output << yield
+          output << "</#{name}>".html_safe
+        end
+      end
+    end
+
+    def link_to(text, target)
+      tag(:a, href: target.url) { text }
+    end
+
     class << self
       # Factory method that returns a newly created view for the given node.
       # It also makes sure all available _view.rb extensions are loaded.

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -41,5 +41,9 @@ describe "tag helpers" do
     it "generated a correct a tag" do
       expect(view.link_to("Bar", bar)).to eq(%{<a href="/bar">Bar</a>})
     end
+
+    it "can use custom HTML attributes" do
+      expect(view.link_to("Bar", bar, class: "foo")).to eq(%{<a class="foo" href="/bar">Bar</a>})
+    end
   end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -15,14 +15,30 @@ describe Flutterby::View do
     let(:source) { %{<%= raw(h "<g>") %>} }
     its(:body) { is_expected.to eq('&lt;g&gt;') }
   end
+end
+
+describe "tag helpers" do
+  let(:root) { node "/" }
+  let(:foo)  { node "foo", parent: root }
+  let(:bar)  { node "bar", parent: root }
+  let(:view) { Flutterby::View.for(foo) }
+
+  describe '#tag' do
+    it "generates HTML tags" do
+      expect(view.tag(:div, class: "foo")).to eq(%{<div class="foo"></div>})
+    end
+
+    it "properly escapes quotes in attributes" do
+      expect(view.tag(:div, class: "foo\"bar")).to eq(%{<div class="foo&quot;bar"></div>})
+    end
+
+    it "properly escapes quotes in tag names" do
+      expect(view.tag("foo\"bar", class: "foo")).to eq(%{<foo&quot;bar class="foo"></foo&quot;bar>})
+    end
+  end
 
   describe '#link_to' do
-    let(:root) { node "/" }
-    let(:foo)  { node "foo", parent: root }
-    let(:bar)  { node "bar", parent: root }
-    let(:view) { Flutterby::View.for(foo) }
-
-    specify do
+    it "generated a correct a tag" do
       expect(view.link_to("Bar", bar)).to eq(%{<a href="/bar">Bar</a>})
     end
   end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -15,4 +15,15 @@ describe Flutterby::View do
     let(:source) { %{<%= raw(h "<g>") %>} }
     its(:body) { is_expected.to eq('&lt;g&gt;') }
   end
+
+  describe '#link_to' do
+    let(:root) { node "/" }
+    let(:foo)  { node "foo", parent: root }
+    let(:bar)  { node "bar", parent: root }
+    let(:view) { Flutterby::View.for(foo) }
+
+    specify do
+      expect(view.link_to("Bar", bar)).to eq(%{<a href="/bar">Bar</a>})
+    end
+  end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -38,8 +38,12 @@ describe "tag helpers" do
   end
 
   describe '#link_to' do
-    it "generated a correct a tag" do
+    it "generates links to nodes" do
       expect(view.link_to("Bar", bar)).to eq(%{<a href="/bar">Bar</a>})
+    end
+
+    it "generates links to URL strings" do
+      expect(view.link_to("Bar", "http://bar.com")).to eq(%{<a href="http://bar.com">Bar</a>})
     end
 
     it "can use custom HTML attributes" do


### PR DESCRIPTION
Views now have `tag` and `link_to` helpers to generate HTML tags (and links) programatically. The `link_to` helper can take a node as its target.